### PR TITLE
Seqbind

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,6 +25,7 @@
   {test, [
     {deps, [ {katana_test, {git, "https://github.com/inaka/katana-test.git", {tag, "0.0.6"}}}
            , {mixer,       {git, "https://github.com/inaka/mixer.git",       {tag, "0.1.5"}}}
+           , {seqbind,     {git, "https://github.com/lpgauth/seqbind.git",   {branch, "master"}}}
            , {meck,       "0.8.3"}
     ]}
   ]},

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
   {test, [
     {deps, [ {katana_test, {git, "https://github.com/inaka/katana-test.git", {tag, "0.0.6"}}}
            , {mixer,       {git, "https://github.com/inaka/mixer.git",       {tag, "0.1.5"}}}
-           , {seqbind,     {git, "https://github.com/lpgauth/seqbind.git",   {branch, "master"}}}
+           , {seqbind,     {git, "https://github.com/lpgauth/seqbind.git",   {ref, "3a4b344"}}}
            , {meck,       "0.8.3"}
     ]}
   ]},

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1244,7 +1244,4 @@ uses_seq_bindings(Root) ->
                             lists:last(ktn_code:attr(text, Node)) =:= $@
                     end,
                     Root),
-    case SeqBindings of
-        [] -> false;
-        _  -> true
-    end.
+    SeqBindings /= [].

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -24,7 +24,8 @@
          max_function_length/3,
          no_debug_call/3,
          no_nested_try_catch/3,
-         no_seqbind/3
+         no_seqbind/3,
+         no_useless_seqbind/3
         ]).
 
 -define(LINE_LENGTH_MSG, "Line ~p is too long: ~s.").
@@ -117,6 +118,9 @@
 
 -define(NO_SEQBIND,
         "Declaration of seqbind at line ~p.").
+
+-define(NO_USELESS_SEQBIND,
+        "Module declares seqbind on line ~p, but no seq-bindings are used.").
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Rules
@@ -1188,7 +1192,6 @@ check_nested_try_catchs(ResultFun, TryExp) ->
                     elvis_code:find(Predicate, TryExp)).
 
 
-
 %% Disallow `-compile({parse_trans, seqbind})`
 -spec no_seqbind(elvis_config:config(),
                  elvis_file:file(),
@@ -1212,3 +1215,36 @@ declares_seqbind(Decls) when is_list(Decls) ->
     lists:keyfind(parse_transform, 1, Decls) =:= {parse_transform, seqbind};
 declares_seqbind(Singleton) ->
     Singleton =:= {parse_transform, seqbind}.
+
+
+%% Warn when `-compile({parse_trans, seqbind})` is declared,
+%% but no seq-bindings (i.e., VarName@) are used in the module.
+-spec no_useless_seqbind(elvis_config:config(),
+                         elvis_file:file(),
+                         empty_rule_config()) ->
+    [elvis_result:item()].
+no_useless_seqbind(Config, Target, _RuleConfig) ->
+    {Root, _} = elvis_file:parse_tree(Config, Target),
+    ResultFun = result_node_line_fun(?NO_USELESS_SEQBIND),
+    SeqbindDecls = elvis_code:find(fun is_seqbind_declaration/1, Root),
+    case SeqbindDecls of
+        [] -> [];
+        _ ->
+            case uses_seq_bindings(Root) of
+                true -> [];
+                false -> lists:map(ResultFun, SeqbindDecls)
+            end
+    end.
+
+
+uses_seq_bindings(Root) ->
+    SeqBindings = elvis_code:find(
+                    fun(Node) ->
+                            ktn_code:type(Node) =:= var andalso
+                            lists:last(ktn_code:attr(text, Node)) =:= $@
+                    end,
+                    Root),
+    case SeqBindings of
+        [] -> false;
+        _  -> true
+    end.

--- a/test/examples/fail_no_seqbind.erl
+++ b/test/examples/fail_no_seqbind.erl
@@ -1,0 +1,5 @@
+-module(fail_no_seqbind).
+
+-compile({parse_transform, seqbind}).
+-compile([{parse_transform, seqbind}]).
+-compile([export_all, {parse_transform, seqbind}]).

--- a/test/examples/fail_no_useless_seqbind.erl
+++ b/test/examples/fail_no_useless_seqbind.erl
@@ -1,0 +1,10 @@
+-module(fail_no_useless_seqbind).
+
+-compile({parse_transform, seqbind}).
+
+-export([demo/0]).
+
+demo() ->
+    X1 = 10,
+    X2 = X1 + 1,
+    X2.

--- a/test/examples/pass_no_useless_seqbind.erl
+++ b/test/examples/pass_no_useless_seqbind.erl
@@ -1,0 +1,10 @@
+-module(pass_no_useless_seqbind).
+
+-compile({parse_transformer, seqbind}).
+
+-export([demo/0]).
+
+demo() ->
+    X@ = 10,
+    X@ = X@ + 1,
+    X@.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -32,6 +32,7 @@
          verify_no_debug_call/1,
          verify_no_nested_try_catch/1,
          verify_no_seqbind/1,
+         verify_no_useless_seqbind/1,
          %% Non-rule
          results_are_ordered_by_line/1
         ]).
@@ -556,15 +557,23 @@ verify_no_nested_try_catch(_Config) ->
 -spec verify_no_seqbind(config()) -> any().
 verify_no_seqbind(_Config) ->
     ElvisConfig = elvis_config:default(),
-    SrcDirs = elvis_config:dirs(ElvisConfig),
-    Path = "fail_no_seqbind.erl",
-    {ok, File} = elvis_test_utils:find_file(SrcDirs, Path),
+    SrcDirs = ["../../test/examples"],
+    File = "fail_no_seqbind.erl",
+    {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
     [
      #{line_num := 3},
      #{line_num := 4},
      #{line_num := 5}
-    ] = elvis_style:no_seqbind(ElvisConfig, File, #{}).
+    ] = elvis_style:no_seqbind(ElvisConfig, Path, #{}).
 
+-spec verify_no_useless_seqbind(config()) -> any().
+verify_no_useless_seqbind(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    SrcDirs = ["../../test/examples"],
+    {ok, PassPath} = elvis_test_utils:find_file(SrcDirs, "pass_no_useless_seqbind.erl"),
+    {ok, FailPath} = elvis_test_utils:find_file(SrcDirs, "fail_no_useless_seqbind.erl"),
+    [] = elvis_style:no_useless_seqbind(ElvisConfig, PassPath, #{}),
+    [#{line_num := 3}] = elvis_style:no_useless_seqbind(ElvisConfig, FailPath, #{}).
 
 -spec results_are_ordered_by_line(config()) -> true.
 results_are_ordered_by_line(_Config) ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -31,6 +31,7 @@
          verify_max_function_length/1,
          verify_no_debug_call/1,
          verify_no_nested_try_catch/1,
+         verify_no_seqbind/1,
          %% Non-rule
          results_are_ordered_by_line/1
         ]).
@@ -551,6 +552,19 @@ verify_no_nested_try_catch(_Config) ->
      #{line_num := 28},
      #{line_num := 35}
     ] = elvis_style:no_nested_try_catch(ElvisConfig, File, #{}).
+
+-spec verify_no_seqbind(config()) -> any().
+verify_no_seqbind(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+    Path = "fail_no_seqbind.erl",
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, Path),
+    [
+     #{line_num := 3},
+     #{line_num := 4},
+     #{line_num := 5}
+    ] = elvis_style:no_seqbind(ElvisConfig, File, #{}).
+
 
 -spec results_are_ordered_by_line(config()) -> true.
 results_are_ordered_by_line(_Config) ->


### PR DESCRIPTION
seqbind [1] is a parse transform for Erlang that allows the programmer to assign to "the same variable" multiples times, e.g.,

``` erlang
X@ = 10,
X@ = X@ + 1.
```

Although this transform can be useful at times, even its author recommends using it sparingly since it obscures the functional nature of Erlang, and can look quite ugly.

This PR adds:

- an elvis_style rule warning the user when a module declares its intention to use seqbind; 
- an elvis_style rule warning the user when a module declares the seqbind parse transform, but never actually uses it (i.e., complete absence of `Var@` in the module).