### PR TITLE
Add linter for possibly forgotten seqbinds

### DIFF
--- a/test/examples/fail_forgot_seqbind.erl
+++ b/test/examples/fail_forgot_seqbind.erl
@@ -1,0 +1,25 @@
+-module(fail_forgot_seqbind).
+
+-compile({parse_transform, seqbind}).
+
+-export([abs1/1, abs2/1, abs3/1, abs4/1]).
+
+%% seqbinds everywhere
+abs1(X@) when X@ < 0          -> X@ * -1;
+abs1(X@) when X@ == 0; X@ > 0 -> X@.
+
+
+%% seqbind forgotten in guards
+abs2(X@) when X@ < 0 -> X@ * - 1;
+abs2(X@) when X == 0 -> X@;
+abs2(X@) when X > 0  -> X@.
+
+
+%% seqbind forgotten in multiple guards
+abs3(X@) when X == 0; X > 0 -> X@;
+abs3(X@)                    -> X@ * -1.
+
+
+%% seqbind forgotten in expression body
+abs4(X@) when X@ < 0 -> X * -1;
+abs4(X@)             -> X.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -33,6 +33,7 @@
          verify_no_nested_try_catch/1,
          verify_no_seqbind/1,
          verify_no_useless_seqbind/1,
+         verify_forgot_seqbind/1,
          %% Non-rule
          results_are_ordered_by_line/1
         ]).
@@ -574,6 +575,22 @@ verify_no_useless_seqbind(_Config) ->
     {ok, FailPath} = elvis_test_utils:find_file(SrcDirs, "fail_no_useless_seqbind.erl"),
     [] = elvis_style:no_useless_seqbind(ElvisConfig, PassPath, #{}),
     [#{line_num := 3}] = elvis_style:no_useless_seqbind(ElvisConfig, FailPath, #{}).
+
+
+-spec verify_forgot_seqbind(config()) -> any().
+verify_forgot_seqbind(_Config) ->
+    ElvisConfig = elvis_config:default(),
+    SrcDirs = ["../../test/examples"],
+    File = "fail_forgot_seqbind.erl",
+    {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
+    [
+     #{line_num := 14},
+     #{line_num := 15},
+     #{line_num := 19},
+     #{line_num := 24},
+     #{line_num := 25}
+    ] = elvis_style:forgot_seqbind(ElvisConfig, Path, #{}).
+
 
 -spec results_are_ordered_by_line(config()) -> true.
 results_are_ordered_by_line(_Config) ->


### PR DESCRIPTION
If a function uses two variables that differ only by the suffix "@",
warn the user that he may have forgotten to properly name a seq-binding.

Example:

        f() ->
          X@ = 1,
          X = X@ + 1, % Did you mean "X@ = X@ + 1"?
          X.